### PR TITLE
fix: preserve externally provided earcut pool

### DIFF
--- a/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
@@ -199,6 +199,7 @@ export class GeoArrowSolidPolygonLayer<
     triangles: Uint32Array | null;
     earcutWorkerPool: Pool<FunctionThread> | null;
     earcutWorkerRequest: Promise<string> | null;
+    ownsEarcutWorkerPool: boolean;
   };
 
   override initializeState(_context: LayerContext): void {
@@ -211,6 +212,7 @@ export class GeoArrowSolidPolygonLayer<
           ? null
           : fetch(this.props.earcutWorkerUrl).then((resp) => resp.text()),
       earcutWorkerPool: this.props.earcutWorkerPool || null,
+      ownsEarcutWorkerPool: false,
     };
   }
 
@@ -243,6 +245,7 @@ export class GeoArrowSolidPolygonLayer<
         this.props.earcutWorkerPoolSize || 1,
       );
       this.state.earcutWorkerPool = pool;
+      this.state.ownsEarcutWorkerPool = true;
       return this.state.earcutWorkerPool;
     } catch (_err) {
       return null;
@@ -250,7 +253,9 @@ export class GeoArrowSolidPolygonLayer<
   }
 
   override async finalizeState(_context: LayerContext): Promise<void> {
-    await this.state?.earcutWorkerPool?.terminate();
+    if (this.state?.ownsEarcutWorkerPool) {
+      await this.state?.earcutWorkerPool?.terminate();
+    }
     console.log("terminated");
   }
 

--- a/packages/deck.gl-geoarrow/tests/solid-polygon-layer.test.ts
+++ b/packages/deck.gl-geoarrow/tests/solid-polygon-layer.test.ts
@@ -1,0 +1,24 @@
+import type { FunctionThread, Pool } from "threads";
+import { describe, expect, it, vi } from "vitest";
+import { GeoArrowSolidPolygonLayer } from "../src/layers/solid-polygon-layer.js";
+
+describe("GeoArrowSolidPolygonLayer earcut worker pool lifecycle", () => {
+  it("does not terminate an externally provided worker pool", async () => {
+    const terminate = vi.fn(async () => {});
+
+    const externalPool = {
+      terminate,
+    } as unknown as Pool<FunctionThread>;
+
+    const layer = new GeoArrowSolidPolygonLayer({
+      id: "test-layer",
+      data: null as never,
+      earcutWorkerPool: externalPool,
+    });
+
+    layer.initializeState({} as never);
+    await layer.finalizeState({} as never);
+
+    expect(terminate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #218.

This change tracks whether the layer created the pool itself. If it did, it terminates the pool during finalization. If the pool was passed in externally, the layer does not terminate the pool.

A regression test was added to verify that an externally provided pool is not terminated.