### PR TITLE
feat: add subpath exports for individual layer modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Standalone examples exist in the [`examples/`](examples/) directory. Create an i
 
 More hosted examples on Observable are planned.
 
+## Importing individual layers
+
+Every layer is exported from the package root. Each layer is also available from its own subpath, named after its module:
+
+```ts
+import { GeoArrowPathLayer } from "@geoarrow/deck.gl-geoarrow/layers/path-layer";
+import { GeoArrowPolygonLayer } from "@geoarrow/deck.gl-geoarrow/layers/polygon-layer";
+import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-geoarrow/layers/scatterplot-layer";
+```
+
+Importing from a subpath means your bundler only resolves the dependencies of the layers you use. For example, the imports above never load `@deck.gl/geo-layers` (used by the A5, Geohash, H3 hexagon, S2, and trips layers) or `@deck.gl/aggregation-layers` (used by the heatmap layer).
+
 ## Providing accessors
 
 All deck.gl layers have two types of properties: ["Render Options"](https://deck.gl/docs/api-reference/layers/scatterplot-layer#render-options) — constant properties across a layer — and "Data Accessors" — properties that can vary across rows. An accessor is any property prefixed with `get`, like `GeoArrowScatterplotLayer`'s `getFillColor`.

--- a/packages/deck.gl-geoarrow/package.json
+++ b/packages/deck.gl-geoarrow/package.json
@@ -9,7 +9,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./layers/*": {
+      "types": "./dist/layers/*.d.ts",
+      "default": "./dist/layers/*.js"
+    },
+    "./layers/text-layer": null
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Closes #221

## Summary

Adds a `./layers/*` subpath export so each layer module can be imported on its own:

```ts
import { GeoArrowPolygonLayer } from "@geoarrow/deck.gl-geoarrow/layers/polygon-layer";
```

Importing through the package root makes the bundler resolve every layer module before tree-shaking. That includes the ones that import @deck.gl/geo-layers (A5, Geohash, H3 hexagon, S2, trips) and @deck.gl/aggregation-layers (heatmap). With subpaths, an app that only uses, say, the path, polygon, and scatterplot layers never has to resolve those packages.

### Changes

- package.json: add `./layers/*` pointing at `dist/layers/*.js` / `*.d.ts`. The root "." export is unchanged.
- `./layers/text-layer: null` keeps the experimental text layer out of the subpaths, so it is still only reachable as `_GeoArrowTextLayer` from the root.
- README: short section documenting the subpath imports.

Note that a subpath exposes everything its module exports, e.g. `defaultProps` from `path-layer` and `getPolygonExterior`/`getMultiPolygonExterior` from `polygon-layer`. Happy to switch to an explicit list of layer entries, or adjust those module exports, if you'd prefer to keep them out of the public surface.

### Testing

- pnpm typecheck, pnpm test, and biome ci . pass.
- Packed the package with pnpm pack and bundled it with Vite in a consumer project that has @deck.gl/core and @deck.gl/layers, but not @deck.gl/geo-layers or @deck.gl/aggregation-layers:
  - importing path/polygon/scatterplot from the root fails: failed to resolve import "@deck.gl/geo-layers" from ".../dist/layers/trips-layer.js"
  - importing the same layers from their subpaths bundles without pulling in either package
  - layers/text-layer is rejected by Vite, Node (ERR_PACKAGE_PATH_NOT_EXPORTED) and TypeScript (TS2307)
- TypeScript (moduleResolution: "bundler") resolves the subpath declaration files with full types.