### PR TITLE
feat: mark geo-layers and aggregation-layers as optional peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Standalone examples exist in the [`examples/`](examples/) directory. Create an i
 
 More hosted examples on Observable are planned.
 
+## Importing individual layers
+
+Every layer is exported from the package root. Each layer is also available from its own subpath, named after its module:
+
+```ts
+import { GeoArrowPathLayer } from "@geoarrow/deck.gl-geoarrow/layers/path-layer";
+import { GeoArrowPolygonLayer } from "@geoarrow/deck.gl-geoarrow/layers/polygon-layer";
+import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-geoarrow/layers/scatterplot-layer";
+```
+
+Importing from a subpath means your bundler only resolves the dependencies of the layers you use. For example, the imports above never load `@deck.gl/geo-layers` (used by the A5, Geohash, H3 hexagon, S2, and trips layers) or `@deck.gl/aggregation-layers` (used by the heatmap layer).
+
 ## Providing accessors
 
 All deck.gl layers have two types of properties: ["Render Options"](https://deck.gl/docs/api-reference/layers/scatterplot-layer#render-options) — constant properties across a layer — and "Data Accessors" — properties that can vary across rows. An accessor is any property prefixed with `get`, like `GeoArrowScatterplotLayer`'s `getFillColor`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-geoarrow/layers/scat
 
 Importing from a subpath means your bundler only resolves the dependencies of the layers you use. For example, the imports above never load `@deck.gl/geo-layers` (used by the A5, Geohash, H3 hexagon, S2, and trips layers) or `@deck.gl/aggregation-layers` (used by the heatmap layer).
 
+`@deck.gl/geo-layers` and `@deck.gl/aggregation-layers` are optional peer dependencies, so package managers don't install them automatically. Install them yourself if you use a layer that needs them, or if you import anything from the package root, since the root entry point loads every layer.
+
 ## Providing accessors
 
 All deck.gl layers have two types of properties: ["Render Options"](https://deck.gl/docs/api-reference/layers/scatterplot-layer#render-options) — constant properties across a layer — and "Data Accessors" — properties that can vary across rows. An accessor is any property prefixed with `get`, like `GeoArrowScatterplotLayer`'s `getFillColor`.

--- a/packages/deck.gl-geoarrow/package.json
+++ b/packages/deck.gl-geoarrow/package.json
@@ -9,7 +9,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./layers/*": {
+      "types": "./dist/layers/*.d.ts",
+      "default": "./dist/layers/*.js"
+    },
+    "./layers/text-layer": null
   },
   "sideEffects": false,
   "files": [

--- a/packages/deck.gl-geoarrow/package.json
+++ b/packages/deck.gl-geoarrow/package.json
@@ -41,6 +41,14 @@
     "@math.gl/polygon": "^4.1.0",
     "apache-arrow": ">=15"
   },
+  "peerDependenciesMeta": {
+    "@deck.gl/aggregation-layers": {
+      "optional": true
+    },
+    "@deck.gl/geo-layers": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@deck.gl/aggregation-layers": "^9.2.1",
     "@deck.gl/core": "^9.2.1",


### PR DESCRIPTION
Closes #222

> [!NOTE]
> Depends on #224. Until that merges, this diff includes its commit. Only the last commit is new here: [view it on its own](https://github.com/jsve/deck.gl-geoarrow/compare/fix/layer-subpath-exports...fix/optional-specialized-peers).

## Summary

`@deck.gl/geo-layers` is only used by the A5, Geohash, H3 hexagon, S2, and trips layers, and `@deck.gl/aggregation-layers` only by the heatmap layer. This marks both as optional in `peerDependenciesMeta`, so npm and pnpm stop installing them automatically for apps that don't use those layers.

The remaining peers (`@deck.gl/core`, `@deck.gl/layers`, `@math.gl/polygon`, `apache-arrow`) stay required.

## Behavior change to be aware of

The root entry point still imports every layer, and bundlers resolve every import before tree-shaking. Vite/Rolldown and esbuild both fail to resolve `@deck.gl/geo-layers` when importing even just `GeoArrowScatterplotLayer` from the root without it installed. So an app that imports from the root and relied on npm/pnpm installing these peers automatically will need to add them to its own dependencies. Apps using the `deck.gl` umbrella package already have both.

That's why this builds on #224: with subpath imports, apps using only the basic layers don't need either package. The README section from #224 now documents when to install them.

## Testing

Resolved a consumer depending on `@deck.gl/core`, `@deck.gl/layers`, and `apache-arrow` plus the packed package:

| | npm | pnpm |
|---|---|---|
| before | 150 packages, both installed | 150 resolved, both installed |
| after | 63 packages, neither installed | 63 resolved, neither installed |

- `pnpm install --frozen-lockfile` passes and `pnpm-lock.yaml` is unchanged (the lockfile doesn't record the package's own peer metadata).
- `biome ci .` passes.
- The examples in the workspace are unaffected. Most depend on the `deck.gl` umbrella package, and inside the workspace the package's devDependencies still provide both.