### PR TITLE
fix: remove console output when polygon layers are finalized

### DIFF
--- a/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
@@ -256,7 +256,6 @@ export class GeoArrowSolidPolygonLayer<
     if (this.state?.ownsEarcutWorkerPool) {
       await this.state?.earcutWorkerPool?.terminate();
     }
-    console.log("terminated");
   }
 
   async updateData() {


### PR DESCRIPTION
Closes #223

`GeoArrowSolidPolygonLayer.finalizeState()` logged `"terminated"` every time a layer was finalized. That includes layers using an external `earcutWorkerPool`, which since #219 don't terminate anything. Apps that render one layer per record batch finalize many layers during normal viewport changes, and had no way to silence the output.

The log dates back to the first worker implementation in #85 and looks like leftover debug output, so this PR just removes it. The opt-in `metrics` timing output is unchanged.

If you'd rather keep a lifecycle diagnostic, I'm happy to switch this to deck.gl's own logger instead, without adding a new prop. It would log only when the layer terminates a pool it created, and only when the app raises the deck.gl log level:

```ts
import { log } from "@deck.gl/core";

if (this.state?.ownsEarcutWorkerPool) {
  await this.state?.earcutWorkerPool?.terminate();
  log.log(1, `${this.id}: terminated earcut worker pool`)();
}
```